### PR TITLE
First batch of fixes

### DIFF
--- a/addons/jc.godot.time-of-day-common/Scenes/Moon/MoonRender.tscn
+++ b/addons/jc.godot.time-of-day-common/Scenes/Moon/MoonRender.tscn
@@ -1,16 +1,15 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=3 format=3 uid="uid://hyy7u72h77"]
 
-[sub_resource type="StandardMaterial3D" id=1]
-flags_unshaded = true
+[sub_resource type="StandardMaterial3D" id="1"]
+shading_mode = 0
 
-[sub_resource type="SphereMesh" id=2]
+[sub_resource type="SphereMesh" id="2"]
 
 [node name="MoonRender" type="SubViewport"]
-size = Vector2(512, 512)
-own_world = true
+own_world_3d = true
 transparent_bg = true
-msaa = 3
-render_target_update_mode = 3
+msaa_3d = 3
+render_target_update_mode = 4
 
 [node name="MoonTransform" type="Node3D" parent="."]
 
@@ -20,8 +19,7 @@ projection = 1
 size = 2.59
 
 [node name="Mesh" type="MeshInstance3D" parent="MoonTransform/Camera3D"]
-transform = Transform3D(4.37114e-08, -1, -3.25841e-07, -1, -4.37114e-08, 0, -1.4243e-14, 3.25841e-07, -1, -4.00785e-07, 0, -1.23)
-material_override = SubResource( 1 )
+transform = Transform3D(8.74228e-08, -2, -7.78829e-07, -2, -8.74228e-08, 6.77626e-20, -3.40438e-14, 7.78829e-07, -2, -4.00785e-07, 0, -1.23)
+material_override = SubResource("1")
 cast_shadow = 0
-mesh = SubResource( 2 )
-surface_material_override/0 = null
+mesh = SubResource("2")

--- a/addons/jc.godot.time-of-day-common/Shaders/CloudsCumulus.gdshader
+++ b/addons/jc.godot.time-of-day-common/Shaders/CloudsCumulus.gdshader
@@ -35,7 +35,7 @@ uniform vec4 _clouds_day_color: source_color;
 uniform vec4 _clouds_horizon_light_color: source_color;
 uniform vec4 _clouds_night_color: source_color;
 
-const int kCLOUDS_STEP = 10;
+const int kCLOUDS_STEP = 5;
 
 uniform vec3 _clouds_partial_mie_phase;
 uniform float _clouds_mie_intensity;

--- a/addons/jc.godot.time-of-day-common/Shaders/PerVertexSky.gdshader
+++ b/addons/jc.godot.time-of-day-common/Shaders/PerVertexSky.gdshader
@@ -52,7 +52,7 @@ uniform float _sun_disk_intensity;
 uniform float _sun_disk_size;
 
 uniform vec4 _moon_color: source_color;
-uniform sampler2D _moon_texture: source_color;
+uniform sampler2D _moon_texture: source_color, repeat_disable;
 
 // Background.
 uniform sampler2D _background_texture: source_color;
@@ -299,5 +299,6 @@ void fragment(){
 	col.rgb = mix(col.rgb, _ground_color.rgb * scatter, saturate((-worldPos.y - _atm_level_params.z)*100.0));
 	
 	col.rgb = tonemapPhoto(col.rgb, _color_correction_params.y, _color_correction_params.x);
+
 	ALBEDO = col.rgb;
 }

--- a/addons/jc.godot.time-of-day-common/Shaders/Sky.gdshader
+++ b/addons/jc.godot.time-of-day-common/Shaders/Sky.gdshader
@@ -52,7 +52,7 @@ uniform float _sun_disk_intensity;
 uniform float _sun_disk_size;
 
 uniform vec4 _moon_color: source_color;
-uniform sampler2D _moon_texture: source_color;
+uniform sampler2D _moon_texture: source_color, repeat_disable;
 
 // Background.
 uniform sampler2D _background_texture: source_color;


### PR DESCRIPTION
This PR makes multiple fixes:
1. MoonRender.tscn is SubViewport that renders the moon texture. The PR updates it so it works correctly in the Godot 4.
2. Since the default SubViewport repeat mode changed to "repeat" in Godot 4(see [this](https://github.com/godotengine/godot/issues/73373?ysclid=lq8wyogxhp526635129) for more info). Shaders, that use the moon texture, had been updated with "repeat_disable" instructions.
3. It lowers kCLOUDS_STEP from 10 to 5. Which fixes the green clouds issue. kCLOUDS_STEP determines how many times the clouds rendering `for` works in the CloudsCumulus.gdshader. It seems that "Forward+" renderer have issues when a shader has too many instructions. Btw, alternative solution is to switch renderer to "Compatibility". Then kCLOUDS_STEP could remain 10.

That's how the sample looks with those fixes:

https://github.com/TokisanGames/TimeOfDay/assets/1057289/2b78c918-663f-4e67-a363-b8b46fbd01e4


