### PR TITLE
compatibility fix

### DIFF
--- a/addons/sky_3d/shaders/AtmFog.gdshader
+++ b/addons/sky_3d/shaders/AtmFog.gdshader
@@ -187,7 +187,8 @@ void vertex(){
 
 void fragment(){
 	float depthRaw = texture(DEPTH_TEXTURE, SCREEN_UV).r;
-
+	depthRaw = PROJECTION_MATRIX[3][2] > PROJECTION_MATRIX[2][2] ? depthRaw : depthRaw * 2.0 - 1.0;
+	
 	vec3 view; vec3 worldPos;
 	computeCoords(SCREEN_UV, depthRaw, camera_matrix, INV_PROJECTION_MATRIX, view, worldPos);
 	worldPos = normalize(worldPos);

--- a/addons/sky_3d/shaders/AtmFog.gdshader
+++ b/addons/sky_3d/shaders/AtmFog.gdshader
@@ -187,7 +187,14 @@ void vertex(){
 
 void fragment(){
 	float depthRaw = texture(DEPTH_TEXTURE, SCREEN_UV).r;
-	depthRaw = PROJECTION_MATRIX[3][2] > PROJECTION_MATRIX[2][2] ? depthRaw : depthRaw * 2.0 - 1.0;
+    #ifndef CURRENT_RENDERER
+    // For 4.3 or earlier, will break if far plane is less than 1m.
+    depthRaw = PROJECTION_MATRIX[3][2] > PROJECTION_MATRIX[2][2] ? depthRaw : depthRaw * 2.0 - 1.0;
+    #else
+    #if CURRENT_RENDERER == RENDERER_COMPATIBILITY
+    depthRaw = depthRaw * 2.0 - 1.0;
+    #endif
+    #endif
 	
 	vec3 view; vec3 worldPos;
 	computeCoords(SCREEN_UV, depthRaw, camera_matrix, INV_PROJECTION_MATRIX, view, worldPos);

--- a/addons/sky_3d/shaders/CloudsCumulus.gdshader
+++ b/addons/sky_3d/shaders/CloudsCumulus.gdshader
@@ -195,4 +195,5 @@ void fragment(){
 	
 	ALBEDO = clouds.rgb;
 	ALPHA = pow3(clouds.a);
+	DEPTH = 0.0;
 }

--- a/addons/sky_3d/shaders/PerVertexSky.gdshader
+++ b/addons/sky_3d/shaders/PerVertexSky.gdshader
@@ -296,4 +296,5 @@ void fragment(){
 	col.rgb = tonemapPhoto(col.rgb, _color_correction_params.y, _color_correction_params.x);
 
 	ALBEDO = col.rgb;
+	DEPTH = 0.0;
 }

--- a/addons/sky_3d/shaders/Sky.gdshader
+++ b/addons/sky_3d/shaders/Sky.gdshader
@@ -296,4 +296,5 @@ void fragment(){
 
 	col.rgb = tonemapPhoto(col.rgb, _color_correction_params.y, _color_correction_params.x);
 	ALBEDO = col.rgb;
+	DEPTH = 0.0;
 }


### PR DESCRIPTION
closes #17

The method to determin the correct NDC for the fog is something I just came up with.. should be fine.

No amount of setting POSITION.z in vertex seemed to achieve anything in compatibility, setting DEPTH to 0.0 did work however - normally this comes with the overhead of shifting the draw to the alpha pass, but since those shaders write alpha already, thats not an issue.