### PR TITLE
Fix sun_direction_changed signal in Skydome

### DIFF
--- a/addons/sky_3d/src/Skydome.gd
+++ b/addons/sky_3d/src/Skydome.gd
@@ -326,7 +326,7 @@ func update_sun_coords() -> void:
 	
 	_set_day_state(altitude)
 	emit_signal("sun_transform_changed", _sun_transform)
-	emit_signal("sun_transform_changed", sun_direction())
+	emit_signal("sun_direction_changed", sun_direction())
 	
 	fog_material.set_shader_parameter("sun_direction", sun_direction())
 	


### PR DESCRIPTION
The `sun_transform_changed` signal was being emitted twice by mistake