### PR TITLE
Implements wind speed and direction for the 2D and cumulus clouds.

### DIFF
--- a/addons/sky_3d/shaders/SkyMaterial.gdshader
+++ b/addons/sky_3d/shaders/SkyMaterial.gdshader
@@ -91,8 +91,7 @@ uniform float clouds_sky_tint_fade = 0.5;
 uniform float clouds_intensity = 10.0;
 uniform float clouds_size = 2.0;
 uniform vec2 clouds_uv = vec2(0.16, 0.11);
-uniform float clouds_speed = 0.07;
-uniform vec2 clouds_direction = vec2(0.25);
+uniform vec2 clouds_position = vec2(0.0);
 uniform vec4 clouds_day_color: source_color = vec4(0.824, 0.875, 1.0, 1.0);
 uniform vec4 clouds_horizon_light_color: source_color = vec4(0.98, 0.43, 0.15, 1.0);
 uniform vec4 clouds_night_color: source_color = vec4(0.09, 0.094, 0.129, 1.0);
@@ -107,8 +106,7 @@ uniform float cumulus_clouds_noise_freq = 2.7;
 uniform float cumulus_clouds_sky_tint_fade = 0.0;
 uniform float cumulus_clouds_intensity = 1.0;
 uniform float cumulus_clouds_size = 0.5;
-uniform float cumulus_clouds_speed = 0.05;
-uniform vec3 cumulus_clouds_direction = vec3(0.25, 0.1, 0.25);
+uniform vec3 cumulus_clouds_position = vec3(0.0);
 uniform sampler2D cumulus_clouds_texture;
 uniform vec4 cumulus_clouds_day_color: source_color = vec4(0.824, 0.875, 1.0, 1.0);
 uniform vec4 cumulus_clouds_horizon_light_color: source_color = vec4(0.98, 0.443, 0.15, 1.0);
@@ -287,12 +285,9 @@ vec3 atmosphericScattering(float sr, float sm, vec2 mu, vec3 mult) {
 
 // Clouds
 //------------------------------------------------------------------------------
-float noiseClouds(vec2 coords, vec2 offset, float p_time) {
-	float speed = p_time * clouds_speed * .5; // .5 matches cumulus clouds
-	vec2 wind = offset * speed;
-	vec2 wind2 = (offset + offset) * speed;
-	float a = textureLod(clouds_texture, coords.xy * clouds_uv - wind, 0.0).r;
-	float b = textureLod(clouds_texture, coords.xy * clouds_uv - wind2, 0.0).r;
+float noiseClouds(vec2 coords) {
+	float a = textureLod(clouds_texture, coords.xy * clouds_uv + 0.5 * clouds_position, 0.0).r;
+	float b = textureLod(clouds_texture, coords.xy * clouds_uv + 0.6 * clouds_position, 0.0).r;
 	return ((a + b) * 0.5);
 }
 
@@ -320,11 +315,10 @@ float cloudsFBM(vec3 p, float l) {
 	return ret;
 }
 
-float cloudsDensity(vec2 p, vec2 offset, float p_time) {
-	float d = noiseClouds(p, offset, p_time);
+float cloudsDensity(vec2 p) {
+	float d = noiseClouds(p);
 	float c = 1.0 - clouds_coverage;
 	d = d - c;
-	//d += d;
 	return saturate(d);
 }
 
@@ -341,10 +335,10 @@ float cloudsDensityCumulus(vec3 p, vec3 offset, float t) {
 	return saturate(dens);
 }
 
-vec4 renderClouds(vec3 pos, float p_time) {
+vec4 renderClouds(vec3 pos) {
 	pos.xy = pos.xz / pos.y;
 	pos *= clouds_size;
-	float density = cloudsDensity(pos.xy, clouds_direction, p_time);
+	float density = cloudsDensity(pos.xy);
 	float sh = saturate(exp(-clouds_absorption * density));
 	float a = saturate(density * clouds_thickness);
 	return vec4(vec3(density*sh) * clouds_intensity, a);
@@ -352,7 +346,7 @@ vec4 renderClouds(vec3 pos, float p_time) {
 
 vec4 renderCloudsCumulus(vec3 ro, vec3 rd, float am, vec3 sunPosition, vec3 moonPosition, float p_time) {
 	vec4 ret = vec4(0, 0, 0, 0);
-	vec3 wind = cumulus_clouds_direction * (p_time * cumulus_clouds_speed);
+	vec3 wind = cumulus_clouds_position;
 	float a = 0.0;
 
 	// n and tt doesnt need to be initialized since it would be set by IntersectSphere
@@ -456,7 +450,7 @@ vec3 render_sky(vec3 worldPos, vec3 cloudsPos, vec3 sunPosition, vec3 moonPositi
 
 	// Clouds
 	if (clouds_visible) {
-		vec4 clouds = renderClouds(cloudsPos, p_time);
+		vec4 clouds = renderClouds(cloudsPos);
 		clouds.a = saturate(clouds.a);
 		clouds.rgb *= mix(mix(clouds_day_color.rgb, clouds_horizon_light_color.rgb, angle_mult.x), clouds_night_color.rgb, angle_mult.w);
 

--- a/addons/sky_3d/src/Skydome.gd
+++ b/addons/sky_3d/src/Skydome.gd
@@ -94,8 +94,6 @@ func _ready() -> void:
 	update_clouds_intensity()
 	update_clouds_size()
 	update_clouds_uv()
-	update_clouds_direction()
-	update_clouds_speed()
 	update_clouds_texture()
 	
 	# Clouds cumulus
@@ -110,12 +108,16 @@ func _ready() -> void:
 	update_clouds_cumulus_mie_intensity()
 	update_clouds_cumulus_mie_anisotropy()
 	update_clouds_cumulus_size()
-	update_clouds_cumulus_direction()
-	update_clouds_cumulus_speed()
 	update_clouds_cumulus_texture()
 	
 	# Environment
 	_update_environment()
+
+
+func _process(delta: float) -> void:
+	clouds_position += clouds_speed * delta * clouds_direction
+	sky_material.set_shader_parameter("clouds_position", clouds_position)
+	sky_material.set_shader_parameter("cumulus_clouds_position", -Vector3(clouds_position.x, 0.0, clouds_position.y))
 
 
 func build_scene() -> void:
@@ -1205,6 +1207,7 @@ func set_stars_scintillation_speed(value: float) -> void:
 @export var clouds_direction: Vector2 = Vector2(0.25, 0.25): set = set_clouds_direction
 @export var clouds_speed: float = 0.07: set = set_clouds_speed
 @export var clouds_texture: Texture2D = Sky3D.clouds_texture: set = _set_clouds_texture
+var clouds_position: Vector2 = Vector2(0.0, 0.0)
 
 
 func set_clouds_visible(value: bool) -> void:
@@ -1309,26 +1312,12 @@ func set_clouds_direction(value: Vector2) -> void:
 	if value == clouds_direction:
 		return
 	clouds_direction = value
-	update_clouds_direction()
-	
-
-func update_clouds_direction() -> void:
-	if !is_scene_built:
-		return
-	sky_material.set_shader_parameter("clouds_direction", clouds_direction)
 
 
 func set_clouds_speed(value: float) -> void:
 	if value == clouds_speed:
 		return
 	clouds_speed = value
-	update_clouds_speed()
-	
-
-func update_clouds_speed() -> void:
-	if !is_scene_built:
-		return
-	sky_material.set_shader_parameter("clouds_speed", clouds_speed)
 
 
 func _set_clouds_texture(value: Texture2D) -> void:
@@ -1524,26 +1513,12 @@ func set_clouds_cumulus_direction(value: Vector3) -> void:
 	if value == clouds_cumulus_direction:
 		return
 	clouds_cumulus_direction = value
-	update_clouds_cumulus_direction()
-
-
-func update_clouds_cumulus_direction() -> void:
-	if !is_scene_built:
-		return
-	clouds_cumulus_material.set_shader_parameter("cumulus_clouds_direction", clouds_cumulus_direction)
 
 
 func set_clouds_cumulus_speed(value: float) -> void:
 	if value == clouds_cumulus_speed:
 		return
 	clouds_cumulus_speed = value
-	update_clouds_cumulus_speed()
-
-
-func update_clouds_cumulus_speed() -> void:
-	if !is_scene_built:
-		return
-	clouds_cumulus_material.set_shader_parameter("cumulus_clouds_speed", clouds_cumulus_speed)
 
 
 func _set_clouds_cumulus_texture(value: Texture2D) -> void:


### PR DESCRIPTION
Adds a "Weather" section to the Sky3D node with properties to set both the wind speed (in m/s) and direction (in degrees, measured from the north). Changing these will set the appropriate direction and speed for both the 2D and cumulus clouds in the sky dome.

Also makes a few changes to the sky material shader to allow smooth transitions in the cloud animations when changing either the wind speed or direction. Before, clouds would "skip" whenever you made such changes.