### PR TITLE
Rename `Skydome` to `SkyDome` in existing scenes

### DIFF
--- a/addons/sky_3d/src/Sky3D.gd
+++ b/addons/sky_3d/src/Sky3D.gd
@@ -507,6 +507,9 @@ func _initialize() -> void:
 		moon.owner = get_tree().edited_scene_root
 		moon.shadow_enabled = true
 
+	# DEPRECATED - Remove 2.2
+	if has_node("Skydome"):
+		$Skydome.name = "SkyDome"
 	if has_node("SkyDome"):
 		sky = $SkyDome
 		sky.environment = environment

--- a/addons/sky_3d/src/TimeOfDay.gd
+++ b/addons/sky_3d/src/TimeOfDay.gd
@@ -100,8 +100,11 @@ var _sky_dome: SkyDome
 @export var dome_path: NodePath:
 	set(value):
 		dome_path = value
-		if value:
-			_sky_dome = get_node_or_null(value)
+		if dome_path:
+			# DEPRECATED - Remove 2.2
+			if dome_path == NodePath("../Skydome"):
+				dome_path = NodePath("../SkyDome")
+			_sky_dome = get_node_or_null(dome_path)
 		_update_celestial_coords()
 
 


### PR DESCRIPTION
The new version is looking for nodes called "SkyDome", but old scenes have "Skydome". This renames them.