### PR TITLE
Fix cirrus visibility toggle logic

### DIFF
--- a/addons/sky_3d/src/SkyDome.gd
+++ b/addons/sky_3d/src/SkyDome.gd
@@ -882,8 +882,8 @@ func _check_cloud_processing() -> void:
 ## Toggles visibility of high-altitude cirrus clouds.
 @export var cirrus_visible: bool = true :
 	set(value):
+		cirrus_visible = value
 		if is_scene_built:
-			cirrus_visible = value
 			sky_material.set_shader_parameter("cirrus_visible", value)
 			_check_cloud_processing()
 


### PR DESCRIPTION
When the scene loads, is_scene_built is false, so the value is never stored. Later, _build_scene() re-triggers all setters but get(cirrus_visible) returns the default true instead of your saved false._

The other setters use this pattern 

