### PR TITLE
Fix moon texture gimbal lock using Celestial North Pole orientation

### DIFF
--- a/addons/sky_3d/src/SkyDome.gd
+++ b/addons/sky_3d/src/SkyDome.gd
@@ -398,6 +398,9 @@ func _update_sun_light_energy() -> void:
 
 ## The moon's Transform3D
 var _moon_transform: Transform3D
+## Celestial North Pole direction, set by [TimeOfDay] based on observer latitude.
+## Used to derive the parallactic angle rotation for the moon texture.
+var celestial_north_pole: Vector3 = Vector3.LEFT
 ## We disable the moon DirectionalLight3D by setting [member DirectionalLight3D.shadow_enabled] 
 ## and [member DirectionalLight3D.light_energy] to false and zero respectively
 var moon_light_enabled: bool = true:
@@ -421,8 +424,14 @@ func update_moon_coords() -> void:
 	_moon_transform.origin = TOD_Math.spherical_to_cartesian(moon_altitude, moon_azimuth)
 	# Transform with Vector3.Left which puts the slight gimbal lock on the horizon. Up puts it at the zenith.
 	_moon_transform = _moon_transform.looking_at(Vector3.ZERO, Vector3.LEFT)
-	
-	var moon_basis: Basis = get_parent().moon.get_global_transform().basis.inverse()
+
+	# Moon texture basis: up axis aligns with the Celestial North Pole (parallactic angle).
+	var moon_dir: Vector3 = _moon_transform.origin.normalized()
+	var cnp: Vector3 = celestial_north_pole
+	var cnp_proj: Vector3 = cnp - moon_dir * cnp.dot(moon_dir)
+	var up: Vector3 = cnp_proj.normalized()
+	var right: Vector3 = up.cross(moon_dir)
+	var moon_basis: Basis = Basis(right, up, moon_dir).inverse()
 	sky_material.set_shader_parameter("moon_matrix", moon_basis)
 	fog_material.set_shader_parameter("moon_direction", _moon_transform.origin)
 	if _moon_light_node:

--- a/addons/sky_3d/src/TimeOfDay.gd
+++ b/addons/sky_3d/src/TimeOfDay.gd
@@ -389,11 +389,13 @@ func _update_celestial_coords() -> void:
 				_compute_simple_moon_coords()
 				_sky_dome.moon_altitude = _moon_coords.y
 				_sky_dome.moon_azimuth = _moon_coords.x
-			
+			# Celestial North Pole (SIMPLE convention: +Z = north)
+			_sky_dome.celestial_north_pole = Vector3(0.0, sin(latitude), cos(latitude))
+
 			if compute_deep_space_coords:
 				if _sky_dome.is_scene_built:
 					_sky_dome.sky_material.set_shader_parameter("star_tilt", HALFPI - latitude)
-		
+
 		CelestialMode.REALISTIC:
 			_compute_realistic_sun_coords()
 			_sky_dome.sun_altitude = -_sun_coords.y
@@ -402,7 +404,9 @@ func _update_celestial_coords() -> void:
 				_compute_realistic_moon_coords()
 				_sky_dome.moon_altitude = -_moon_coords.y
 				_sky_dome.moon_azimuth = -_moon_coords.x
-			
+			# Celestial North Pole (REALISTIC convention: -Z = north)
+			_sky_dome.celestial_north_pole = Vector3(0.0, sin(latitude), -cos(latitude))
+
 			if compute_deep_space_coords:
 				if _sky_dome.is_scene_built:
 					_sky_dome.sky_material.set_shader_parameter("star_tilt", latitude - HALFPI)


### PR DESCRIPTION
On the gimbal lock — replaced it with a Gram-Schmidt basis built from the Celestial North Pole, which corresponds to the parallactic angle. The math doesn't degenerate as long as the body never lines up with the up reference.

`TimeOfDay` pushes CNP into `SkyDome` based on observer latitude:

    SIMPLE:    (0, sin(lat),  cos(lat))
    REALISTIC: (0, sin(lat), -cos(lat))

Tested with a Sky3DDemo-based scene running a full day-night cycle — moon texture stays oriented, parallactic angle rotates smoothly.

Auto-camera following the moon — texture rotation is clearer because the moon stays in frame:

https://github.com/user-attachments/assets/bb86e9c0-3f76-4b31-a54d-714fb17918a4

Same cycle, manual camera for a more natural perspective:

https://github.com/user-attachments/assets/99f88aac-f184-497f-b5e2-747be9be34ed

\`+18 / -5\` across \`SkyDome.gd\` and \`TimeOfDay.gd\`.

Fixes #24